### PR TITLE
Removes jsx as a JavaScript React  language identifiers

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -82,7 +82,7 @@ HTML | `html`
 Ini | `ini`
 Java | `java`
 JavaScript | `javascript`
-JavaScript React | `javascriptreact`, `jsx`
+JavaScript React | `javascriptreact`
 JSON | `json`
 JSON with Comments | `jsonc`
 LaTeX | `latex`


### PR DESCRIPTION
It fixes an error in the documentation by removing jsx from the list.
Resolves #4741